### PR TITLE
Revert "Update to a newer build image"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ workflows:
 
 jobs:
   build-releases:
-    machine:
-      image: ubuntu-2004:202104-01
+    # https://github.com/cibuilds/hugo/pull/213
+    machine: true
     steps:
       - checkout
       - run:
@@ -44,8 +44,8 @@ jobs:
               fi
             fi
   build-nightly:
-    machine:
-      image: ubuntu-2004:202104-01
+    # https://github.com/cibuilds/hugo/pull/213
+    machine: true
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Reverts cibuilds/hugo#203

Reverting this change before modern images contain a much newer version of Docker. This newer Docker version doesn't automatically push all tags but just `latest` when you don't specify a tag.

Until this issue is worked around in this repo, reverting this change.