### PR TITLE
:package: :heavy_plus_sign: Dockerfile: Install asciidoctor package

### DIFF
--- a/0.89/Dockerfile
+++ b/0.89/Dockerfile
@@ -13,7 +13,9 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		libffi-dev \
 		rsync \
 		ruby-full \
-		# Needed for the Nokogiri gem
+		# Needed for AsciiDoc support in Hugo \
+		asciidoctor \
+		# Needed for the Nokogiri gem \
 		zlib1g-dev && \
 	sudo gem install html-proofer --no-document
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,7 +13,9 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		libffi-dev \
 		rsync \
 		ruby-full \
-		# Needed for the Nokogiri gem
+		# Needed for AsciiDoc support in Hugo \
+		asciidoctor \
+		# Needed for the Nokogiri gem \
 		zlib1g-dev && \
 	sudo gem install html-proofer --no-document
 


### PR DESCRIPTION
This commit adds the `asciidoctor` package from the official Ubuntu
20.04 repositories. Hugo supports rendering AsciiDoc content, but
requires the `asciidoctor` binary to be in the `$PATH` in order to fully
render AsciiDoc to HTML.

By including `asciidoctor` upstream in the base image, it makes it
easier for downstream implementations to have AsciiDoc support enabled
in Hugo by default.