### PR TITLE
:clipboard: Dockerfile: Clean apt cache, simplify install step for hugo

### DIFF
--- a/0.89/Dockerfile
+++ b/0.89/Dockerfile
@@ -15,12 +15,11 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		ruby-full \
 		# Needed for the Nokogiri gem
 		zlib1g-dev && \
+	sudo apt-get clean && \
 	sudo gem install html-proofer --no-document
 
-RUN wget $HUGO_DOWNLOAD_URL && \
-	tar -xzf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
-	sudo mv hugo /usr/bin/hugo && \
-	rm hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz LICENSE README.md
+RUN curl -L $HUGO_DOWNLOAD_URL | tar xzv hugo && \
+	sudo mv hugo /usr/bin/hugo
 
 
 CMD ["htmlproofer", "--help"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,12 +15,11 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		ruby-full \
 		# Needed for the Nokogiri gem
 		zlib1g-dev && \
+	sudo apt-get clean && \
 	sudo gem install html-proofer --no-document
 
-RUN wget $HUGO_DOWNLOAD_URL && \
-	tar -xzf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
-	sudo mv hugo /usr/bin/hugo && \
-	rm hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz LICENSE README.md
+RUN curl -L $HUGO_DOWNLOAD_URL | tar xzv hugo && \
+	sudo mv hugo /usr/bin/hugo
 
 
 CMD ["htmlproofer", "--help"]


### PR DESCRIPTION
This commit makes the following changes:

* apt: Clean the apt cache after installing packages to contribute to a
  more lean image size.
* Hugo installation: Reduce four commands to two. Makes for easier
  reading and simpler script logic.

Built locally and verified that `hugo` binary works as expected:

```sh
$ podman run --rm -it localhost/hugo-simp:latest bash
circleci@895338fceafa:~/project$ hugo version
hugo v0.89.0-ADE966B8+extended linux/amd64 BuildDate=2021-11-02T10:00:18Z VendorInfo=gohugoio
```