### PR TITLE
Start using Go v1.21 on nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
                 image: hubci/hugo
   build-nightly:
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.21
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
Go 1.21 seems to have changed the mod version syntax in a way that isn't backwards compatible.